### PR TITLE
changed  to , as this was what it required for me to get it to work

### DIFF
--- a/view_management/composing.md
+++ b/view_management/composing.md
@@ -15,4 +15,4 @@ The view can also be set explicitly:
 Complex views can also be composed and set. This is done through the `ViewComposer` object. The way composer works is you specify the path you want to compose at, then override any part of the view (e.g. a template, page, or partial).
 
     ruby:
-    presenter.view = compose_at('some/path', template: 'some_other_template')
+    presenter.view = presenter.compose_at('some/path', template: 'some_other_template')

--- a/view_management/modifying.md
+++ b/view_management/modifying.md
@@ -55,4 +55,4 @@ These contexts are available to the following methods:
 - bind
 - apply
 
-Read more [here](/docs/view_management#traversing).
+Read more [here](/docs/view_management/traversing).


### PR DESCRIPTION
changed `compose_at('some/path', template: 'some_other_template')` to `presenter.compose_at('some/path', template: 'some_other_template')`, as this was what it required for me to get it to work