### PR TITLE
Made a couple of things universal in the docs

### DIFF
--- a/data/_overview.md
+++ b/data/_overview.md
@@ -46,13 +46,13 @@ Dotenv.load
 
 Create a `.env` file in the root of your project and add the following:
 
-```console
+```
 DATABASE_URL=connect_string
 ```
 
 Replace `connect_string` with the connection string for your environment and database. If you're using Postgres, it would look something like this:
 
-```console
+```
 DATABASE_URL=postgres://localhost/my-database-name
 ```
 
@@ -82,7 +82,7 @@ end
 
 Run the migrations against a database like this:
 
-```console
+```
 bundle exec sequel -m ./migrations {connect_string}
 ```
 
@@ -141,7 +141,7 @@ Creates a new migration with provided `name`, automatically prefixed.
 
 Before we can present data we should create some for testing. To keep it easy for this guide, we'll use console. Run `pakyow console` and enter the following commands:
 
-```console
+```
 irb(main):001:0> User.create(name: 'User 1', body: 'user1@pakyow.org')
 irb(main):002:0> User.create(name: 'User 2', body: 'user2@pakyow.org')
 irb(main):003:0> User.create(name: 'User 3', body: 'user3@pakyow.org')

--- a/data/_overview.md
+++ b/data/_overview.md
@@ -163,7 +163,7 @@ Let's create a view that we'll use to present our users. Create an `index.html` 
 </div>
 ```
 
-Run `pakyow server` to start the server, then navigate to [localhost:3000](http://localhost:3000) to see the new view prototype. Now let's bind our user data to it. Open `app/lib/routes.rb` and define a default route. Here's what it should look like:
+Run `bundle exec pakyow server` to start the server, then navigate to [localhost:3000](http://localhost:3000) to see the new view prototype. Now let's bind our user data to it. Open `app/lib/routes.rb` and define a default route. Here's what it should look like:
 
 ```ruby
 Pakyow::App.routes do

--- a/live_views/_overview.md
+++ b/live_views/_overview.md
@@ -216,13 +216,13 @@ ui.mutate(:user)
 Pakyow UI keeps track of what clients should receive what state mutations using
 realtime channels. Here's how a channel is structured:
 
-```console
+```
 scope:{name};mutation{name}::{qualifiers}
 ```
 
 In the example from the Mutators section, the subscribed channel name is:
 
-```console
+```
 scope:user;mutation:list
 ```
 

--- a/start/creating.md
+++ b/start/creating.md
@@ -36,7 +36,7 @@ Using pakyow 0.9.1
 Using puma 2.10.2
 Your bundle is complete!
 Use `bundle show [gemname]` to see where a bundled gem is installed.
-Done! Run `cd my-app; pakyow server` to get started!
+Done! Run `cd my-app; bundle exec pakyow server` to get started!
 ```
 
 Pakyow has generated a project in a new directory and installed

--- a/start/installing.md
+++ b/start/installing.md
@@ -8,7 +8,7 @@ the [Ruby](http://www.ruby-lang.org) programming language.
 You can check the state of your system by running this
 command in your terminal:
 
-```console
+```
 bash <(curl -s https://raw.githubusercontent.com/pakyow/pakyow-deps/master/check.sh)
 ```
 
@@ -55,7 +55,7 @@ Windows users:
 
 Once everything checks out, install Pakyow via RubyGems:
 
-```console
+```
 gem install pakyow
 ```
 

--- a/start/running.md
+++ b/start/running.md
@@ -7,7 +7,7 @@ Pakyow includes a tool for running projects locally during development. To start
 server, run the following command in terminal from the main directory of your project:
 
 ```console
-pakyow server
+bundle exec pakyow server
 ```
 
 You should see some ouput similar to this:

--- a/tools/_overview.md
+++ b/tools/_overview.md
@@ -9,7 +9,7 @@ Pakyow provides several tools useful during development.
 
 The server command runs a local instance of a Pakyow application.
 
-```console
+```
 pakyow server [environment]
 ```
 
@@ -26,7 +26,7 @@ You can run a specific handler by setting the `server.handler` [config option](/
 
 > Elsewhere in this documentation, you'll always see pakyow server executed like this:
 >
->```console
+>```
 >bundle exec pakyow server [environment]
 >```
 >
@@ -40,13 +40,13 @@ You can run a specific handler by setting the `server.handler` [config option](/
 
 The console command loads an application into a REPL (like IRB).
 
-```console
+```
 pakyow console [environment]
 ```
 
 If environment is not specified, the `default_environment` defined in the app will be used. Once started, you can execute Ruby code against your app. If a file is changed, the session can be reloaded, like so:
 
-```console
+```
 reload
 Reloading...
 ```
@@ -55,7 +55,7 @@ Reloading...
 
 Several rake tasks are included with the `pakyow-rake` gem. To use them, add `pakyow-rake` to your `Gemfile` and require it at the top of `Rakefile`. Here's a list of tasks it adds to your app:
 
-```console
+```
 rake --tasks
 rake pakyow:bindings[view_path]  # List bindings across all views, or a specific view path
 rake pakyow:prepare              # Prepare the app by configuring and loading code

--- a/tools/_overview.md
+++ b/tools/_overview.md
@@ -24,6 +24,18 @@ When starting the server, Pakyow will try the following handlers in order:
 
 You can run a specific handler by setting the `server.handler` [config option](/docs/config).
 
+> Elsewhere in this documentation, you'll always see pakyow server executed like this:
+>
+>```console
+>bundle exec pakyow server [environment]
+>```
+>
+>The reasons for this are laid out on the [Bundler home page](http://bundler.io/ "Bundler home page"):
+>
+>>In some cases, running executables without `bundle exec` may work, if the executable happens to be installed in your system and does not pull in any gems that conflict with your bundle.
+>>
+>>However, this is unreliable and is the source of considerable pain. Even if it looks like it works, it may not work in the future or on another machine.
+
 ## Console
 
 The console command loads an application into a REPL (like IRB).

--- a/warmup/data.md
+++ b/warmup/data.md
@@ -12,7 +12,7 @@ hooking into it is relatively straight-forward.
 Make sure you have Redis installed on your local machine. If you use Homebrew
 and OSX, it's easy:
 
-```console
+```
 brew install redis
 ```
 

--- a/warmup/deployment.md
+++ b/warmup/deployment.md
@@ -8,19 +8,19 @@ It's time to deploy our warmup project to Heroku!
 First, our code must be in version control. Initialize a Git repository by
 running the following command:
 
-```console
+```
 git init
 ```
 
 Now, stage the project files:
 
-```console
+```
 git add .
 ```
 
 And commit them:
 
-```console
+```
 git commit -m "initial commit"
 ```
 
@@ -31,19 +31,19 @@ deployment tools.
 
 Next, create your Heroku environment (following any prompts you receive):
 
-```console
+```
 heroku create
 ```
 
 Add Redis to the Heroku environment:
 
-```console
+```
 heroku addons:create heroku-redis:hobby-dev
 ```
 
 Finally, push the project code up to Heroku:
 
-```console
+```
 git push heroku master
 ```
 
@@ -51,7 +51,7 @@ Over the next minute or two, Heroku will build the project and make it available
 for use. When it's finished, type the following command to open your Pakyow
 project in a web browser:
 
-```console
+```
 heroku open
 ```
 

--- a/warmup/start.md
+++ b/warmup/start.md
@@ -55,7 +55,7 @@ Using rspec-mocks 3.4.0
 Using rspec 3.4.0
 Bundle complete! 4 Gemfile dependencies, 30 gems now installed.
 Use `bundle show [gemname]` to see where a bundled gem is installed.
-Done! Run `cd warmup; pakyow server` to get started!
+Done! Run `cd warmup; bundle exec pakyow server` to get started!
 ```
 
 Pakyow creates the entire project structure for us, allowing us to get right to

--- a/warmup/start.md
+++ b/warmup/start.md
@@ -10,13 +10,13 @@ Pakyow ships with a few command-line tools that help you generate and manage
 your projects. These tools make creating a new project really easy. Open up a
 terminal prompt and create a new project:
 
-```console
+```
 pakyow new warmup
 ```
 
 You should see output similar to this:
 
-```console
+```
 Generating project: warmup
 Running `bundle install` in /Users/bryanp/Desktop/warmup
 Fetching gem metadata from https://rubygems.org/...........
@@ -62,7 +62,7 @@ Pakyow creates the entire project structure for us, allowing us to get right to
 work. Move into the new `warmup` directory by typing `cd warmup` and then start
 the server with the following command:
 
-```console
+```
 bundle exec pakyow server
 ```
 


### PR DESCRIPTION
1. changed the documentation to universally use: bundle exec pakyow server
2. replaced 3 backticks + console with just 3 backticks

For the first item, the output when creating a new payow project should be tweaked to match what's in the docs.  I could do this, but not sure where that code lives.