### PR TITLE
Use correct variable in example

### DIFF
--- a/concepts/view_transformation_protocol.md
+++ b/concepts/view_transformation_protocol.md
@@ -26,7 +26,7 @@ data << { id: 1, content: 'one' }
 data << { id: 2, content: 'two' }
 data << { id: 3, content: 'three' }
 
-view.scope(:post).apply(content)
+view.scope(:post).apply(data)
 ```
 
 The view rendering can be represented by this bit of JSON:


### PR DESCRIPTION
There is no value named `content` in the example.