### PR TITLE
Remove typo

### DIFF
--- a/realtime/_overview.md
+++ b/realtime/_overview.md
@@ -96,7 +96,7 @@ window.socket.onopen = function (event) {
 
 window.socket.onmessage = function (evt) {
   console.log('socket message');
-  console.log(JSON.parse(evt.data);data);
+  console.log(JSON.parse(evt.data));
 };
 ```
 


### PR DESCRIPTION
Changing `console.log(JSON.parse(evt.data);data);` to `console.log(JSON.parse(evt.data));`